### PR TITLE
Fix Layout animations on react-web

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,10 +262,12 @@ export function createAnimatableComponent(component) {
           }, delay);
           return;
         }
-        for (let i = LAYOUT_DEPENDENT_ANIMATIONS.length - 1; i >= 0; i--) {
-          if (animation.indexOf(LAYOUT_DEPENDENT_ANIMATIONS[i]) === 0) {
-            this.setState({ scheduledAnimation: animation });
-            return;
+        if (!this._layout) {
+          for (let i = LAYOUT_DEPENDENT_ANIMATIONS.length - 1; i >= 0; i--) {
+            if (animation.indexOf(LAYOUT_DEPENDENT_ANIMATIONS[i]) === 0) {
+              this.setState({ scheduledAnimation: animation });
+              return;
+            }
           }
         }
         onAnimationBegin();


### PR DESCRIPTION
On react-web, onLayout runs before componentDidMount().

Whether or not that behavior is correct, or whether react-web specifically should be supported - this seems like a generic enough change to me.
